### PR TITLE
Fix empty python install

### DIFF
--- a/Python/setup.py
+++ b/Python/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 setup(
     name="met-brewer",
     version="1.0",
+    packages = ["met_brewer"],
     install_requires=[
         "colour>=0.1.5",
         "matplotlib>=3.5.1"


### PR DESCRIPTION
Running either `pip` or `python setup.py install` commands lead to a ModuleNotFoundError when the import is performed out of the Python folder of the git. This addition fix the issue!