### PR TITLE
Tidy up Python implementation and provide installpoint via PyPA

### DIFF
--- a/Python/README.md
+++ b/Python/README.md
@@ -1,0 +1,486 @@
+# MetBrewer <img align="right" src="https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hex/MetBrewerHex.jpg" width=400>
+Palettes inspired by works at the Metropolitan Museum of Art in New York. Pieces selected come from various time periods, regions, and mediums.
+
+![CRAN Version](https://www.r-pkg.org/badges/version/MetBrewer)
+![CRAN Downloads](https://cranlogs.r-pkg.org/badges/MetBrewer)
+
+Structure of the package was based on coding from the [`PNWColors`](https://github.com/jakelawlor/PNWColors) and [`wesanderson`](https://github.com/karthik/wesanderson) packages. Inspired by the package [`RColorBrewer`](https://cran.r-project.org/web/packages/RColorBrewer/RColorBrewer.pdf) from the work of [Cynthia Brewer](http://colorbrewer2.org).
+
+For requests, questions, comments, concerns, or anything else, feel free to reach out to me:<br />
+My Website: [here](https://www.blakerobertmills.com)<br /> Twitter: [here](https://twitter.com/BlakeRobMills)<br /> LinkedIn: [here](https://www.linkedin.com/in/blake-m-79a74513a/) <br />Email: brm2143@columbia.edu
+
+# Table of Contents
+- [MetBrewer ](#metbrewer-)
+  - [Install Package](#install-package)
+    - [R](#r)
+    - [Python](#python)
+  - [Palettes](#palettes)
+  - [Functions](#functions)
+    - [ggplot2 Examples](#ggplot2-examples)
+  - [Colorblind Friendly Checking](#colorblind-friendly-checking)
+
+## Install Package
+### R
+MetBrewer is now able to be downloaded directly through R. You can still download through GitHub as well.
+
+```r
+install.packages("MetBrewer")
+
+install.packages("devtools")
+devtools::install_github("BlakeRMills/MetBrewer")
+```
+
+### Python
+Install via PyPA:
+```
+pip install met-brewer
+```
+or via pip directly from GitHub:
+```
+pip install -e git+https://github.com/BlakeRMills/MetBrewer#subdirectory=Python
+```
+
+For development, install the package under the `Python/` directory:
+```
+python setup.py develop
+```
+or via pip locally:
+```
+pip install -e .
+```
+
+Use it in your code:
+```python
+import met_brewer
+colors = met_brew(name="VanGogh1", n=123, brew_type="continuous")
+```
+
+## Palettes
+
+### All Palettes
+![AllPals](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/AllPalettes.png)
+
+### Archambault
+![Archambault](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Archambault.png)
+- Woman’s Dress and Accessories, 2005, Jodi Archambault, Hunkpapa Lakota (Teton Sioux), [Link](https://www.metmuseum.org/art/collection/search/644324)
+-  Colorblind-Friendly
+***
+
+### Austria
+![Austria](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Austria.png)
+- Adoration of the Magi from Seven Scenes from the Life of Christ, 1390, Artists Unknown, Austrian, [Link](https://www.metmuseum.org/art/collection/search/469959)
+***
+
+### Benedictus
+![Benedictus](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Benedictus.png)
+- Relais, 1930 : quinze planches donnant quarante-deux motifs décoratifs : enluminure d'art de J. Saudé : préliminaires de Y. Rambosson, 1930, Edouard Bénedictus, French, [Link](https://www.metmuseum.org/art/collection/search/812492)
+***
+
+### Cassatt1
+![Cassatt](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Cassatt1.png)
+- The Cup of Tea, 1880-1881, Mary Cassatt, American, [Link](https://www.metmuseum.org/art/collection/search/10388)
+- Colorblind-Friendly
+***
+
+### Cassatt2
+![Cassatt2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Cassatt2.png)
+- Lilacs in a Window (Vase de Lilas à la Fenetre), 1880–83, Mary Cassatt, American, [Link](https://www.metmuseum.org/art/collection/search/13758)
+- Colorblind-Friendly
+***
+
+### Cross
+![Cross](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Cross.png)
+- Cap Nègre, 1909, Henri-Edmond Cross, French, [Link](https://www.metmuseum.org/art/collection/search/459734)
+***
+
+### Degas
+![Degas](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Degas.png)
+- The Rehearsal of the Ballet Onstage, 1874, Edgar Degas, French, [Link](https://www.metmuseum.org/art/collection/search/436155)
+***
+
+### Demuth
+![Demuth](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Demuth.png)
+- I Saw the Figure 5 in Gold, 1928, Charles Demuth, American, [Link](https://www.metmuseum.org/art/collection/search/488315)
+- Colorblind-Friendly
+***
+
+### Derain
+![Derain](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Derain.png)
+- The Palace of Westminster, 1906–1907, André Derain, French, [Link](https://www.metmuseum.org/art/collection/search/459144)
+- Colorblind-Friendly
+***
+
+### Egypt
+![Egypt](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Egypt.png)
+- The King with Isis, Tomb of Haremhab, A.D. 1910–1911; original ca. 1323–1295 B.C., Twentieth Century; original New Kingdom, [Link](https://www.metmuseum.org/art/collection/search/557794?searchField=All&amp;sortBy=Relevance&amp;deptids=10&amp;ao=on&amp;ft=*&amp;offset=0&amp;rpp=80&amp;pos=63)
+- Colorblind-Friendly
+***
+
+### Gauguin
+![Gauguin](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Gauguin.png)
+- A Farm in Brittany, 1874, Paul Gauguin, French, [Link](https://www.metmuseum.org/art/collection/search/436448)
+***
+
+### Greek
+![Greek](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Greek.png)
+- Terracotta neck-amphora (jar), ca. 550–540 B.C., Greek, [Link](https://www.metmuseum.org/art/collection/search/254199)
+- Colorblind-Friendly
+***
+
+### Hiroshige
+![Hiroshige](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hiroshige.png)
+- Sailing Boats Returning to Yabase, Lake Biwa, 1835, Utagawa Hiroshige, Japanese, [Link](https://www.metmuseum.org/art/collection/search/36534)
+- Colorblind-Friendly
+***
+
+### Hokusai1
+![Hokusai](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hokusai1.png)
+- Poem by Gon-Chūnagon Sadaie, from the series One Hundred Poems Explained by the Nurse (Hyakunin isshu uba ga etoki), 1760–1849, Katsushika Hokusai, Japanese, [Link](https://www.metmuseum.org/art/collection/search/56157)
+***
+
+### Hokusai2
+![Hokusai2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hokusai2.png)
+- Lake Suwa in Shinano Province (Shinshū Suwako), from the series Thirty-six Views of Mount Fuji (Fugaku sanjūrokkei), 1830-32, Katsushika Hokusai, Japanese, [Link](https://www.metmuseum.org/art/collection/search/56240)
+- Colorblind-Friendly
+***
+
+### Hokusai3
+![Hokusai3](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hokusai3.png)
+- Yōrō Waterfall in Mino Province (Mino no Yōrō no taki), from the series A Tour of Waterfalls in Various Provinces (Shokoku taki meguri), 1832, Katsushika Hokusai, Japanese, [Link](https://www.metmuseum.org/art/collection/search/56146)
+- Colorblind-Friendly
+***
+
+### Homer1
+![Homer1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Homer1.png)
+- The Veteran in a New Field, 1865, Winslow Homer, American, [Link](https://www.metmuseum.org/art/collection/search/11145)
+***
+
+### Homer2
+![Homer2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Homer2%20(Update).png)
+- Flower Garden and Bungalow, Bermuda, 1899, Winslow Homer, American, [Link](https://www.metmuseum.org/art/collection/search/11121)
+***
+
+### Ingres
+![Ingres](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Ingres.png)
+- Joséphine-Éléonore-Marie-Pauline de Galard de Brassac de Béarn (1825–1860), Princesse de Broglie, 1851–53, Jean Auguste Dominique Ingres, French, [Link](https://www.metmuseum.org/art/collection/search/459106)
+- Colorblind-Friendly
+***
+
+### Isfahan1
+![Isfahan1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Isfahan1%20(Update).png)
+- Mihrab (Prayer Niche), dated A.H. 755/ A.D. 1354–55,  From Iran, Isfahan, [Link](https://www.metmuseum.org/art/collection/search/449537?searchField=All&amp;sortBy=Relevance&amp;ft=Mihrab&amp;offset=0&amp;rpp=20&amp;pos=1)
+- Colorblind-Friendly
+***
+
+### Isfahan2
+![Isfahan2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Isfahan2.png)
+- Garden Gathering, 1640–50, From Iran, Isfahan, [Link](https://www.metmuseum.org/art/collection/search/455082)
+- Colorblind-Friendly
+***
+
+### Java
+![Java](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Java.png)
+- Skirt, 20th Century, Javanese People, Javanese, [Link](https://www.metmuseum.org/art/collection/search/85689)
+- Colorblind-Friendly
+***
+
+### Johnson
+![Johnson](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Johnson.png)
+Jitterbugs V, 1941–42, William Henry Johnson, American, [Link](https://www.metmuseum.org/art/collection/search/491485)
+- Colorblind-Friendly
+***
+
+### Juarez
+![Juarez](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Juarez.png)
+- The Entombment of Christ, 1702, Juan Rodríguez Juárez, Mexican, [Link](https://www.metmuseum.org/art/collection/search/631985)
+***
+
+### Kandinsky
+![Kandinsky](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Kandinsky.png)
+Kleine Welten IV (Small Worlds IV), 1922, Vasily Kandinsky, French, born Russia, [Link](https://www.metmuseum.org/art/collection/search/369093?sortBy=Relevance&amp;ft=Vasily+Kandinsky&amp;offset=0&amp;rpp=40&amp;pos=12)
+- Colorblind-Friendly
+***
+
+### Klimt
+![Klimt](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Klimt.png)
+- Mäda Primavesi (1903–2000), 1912-13, Gustav Klimt, Austrian, [Link](https://www.metmuseum.org/art/collection/search/436819)
+***
+
+### Lakota
+![Lakota](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Lakota.png)
+- Dress, 1870, Lakota/Teton Sioux, Native American, [Link](https://www.metmuseum.org/art/collection/search/751512)
+***
+
+### Manet
+![Manet](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Manet.png)
+- Boating, 1874, Édouard Manet, French, [Link](https://www.metmuseum.org/art/collection/search/436947?searchField=All&amp;sortBy=Relevance&amp;ft=manet&amp;offset=0&amp;rpp=20&amp;pos=8)
+***
+
+### Monet
+![Monet](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Monet.png)
+- Bridge over a Pond of Water Lilies, 1899, Claude Monet, French, [Link](https://www.metmuseum.org/art/collection/search/437127?searchField=All&amp;sortBy=Relevance&amp;ft=Monet&amp;offset=0&amp;rpp=20&amp;pos=4)
+***
+
+### Moreau
+![Moreau](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Moreau.png)
+- Oedipus and the Sphinx, 1864, Gustave Moreau, French, [Link](https://www.metmuseum.org/art/collection/search/437153)
+***
+
+### Morgenstern
+![Morgenstern](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Morgenstern%20(Update).png)
+- Jungfrau, Mönch, and Eiger, 1851, Carl Morgenstern, German, [Link](https://www.metmuseum.org/art/collection/search/440360)
+- Colorblind-Friendly
+***
+
+### Nattier
+![Nattier](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Nattier.png)
+- Madame Bergeret de Frouville as Diana, 1756, Jean Marc Nattier, French, [Link](Link)
+***
+
+### Navajo
+![Navajo](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Navajo.png)
+- Serape, 1865–70, Navajo, [Link](https://www.metmuseum.org/art/collection/search/823657)
+***
+
+### NewKingdom
+![NewKingdom](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/NewKingdom.png)
+- Blue-Painted Ibex Amphora from Malqata, ca. 1390–1353 B.C., New Kingdom, [Link](https://www.metmuseum.org/art/collection/search/544501)
+***
+
+### Nizami
+![Nizami](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Nizami.png)
+- "Laila and Majnun in School", Folio 129 from a Khamsa (Quintet) of Nizami of Ganja, A.H. 931/A.D. 1524–25, Nizami, Made in present-day Afghanistan, Herat, [Link](https://www.metmuseum.org/art/collection/search/446603)
+***
+
+### OKeeffe1
+![OKeeffe1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/OKeeffe1.png)
+- From the Faraway, Nearby, 1937, Georgia O'Keeffe, American, [Link](https://www.metmuseum.org/art/collection/search/489064)
+- Colorblind-Friendly
+***
+
+### OKeeffe2
+![OKeeffe2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/OKeeffe2.png)
+- Red and Yellow Cliffs, 1940, Georgia O'Keeffe, American, [Link](https://www.metmuseum.org/art/collection/search/484833)
+- Colorblind-Friendly
+***
+
+### Paquin
+![Paquin](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Paquin.png)
+- Evening Dress, 1937, House of Paquin by Ana de Pombo, French House, Spanish Designer, [Link](https://www.metmuseum.org/art/collection/search/138291)
+***
+
+### Peru1
+![Peru1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Peru1.png)
+- Ear Ornament, Winged Runner, A.D. 400–700, Moche, Peruvian, [Link](https://www.metmuseum.org/art/collection/search/309428)
+***
+
+### Peru2
+![Peru2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Peru2%20(Update).png)
+- Tunic with Confronting Catfish, A.D. 800–850, Nasca-Wari, Peruvian, [Link](https://www.metmuseum.org/art/collection/search/307975)
+***
+
+### Pillement
+![Pillement](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Pillement.png)
+- A Shipwreck in a Storm, 1782, Jean Pillement, French, [Link](https://www.metmuseum.org/art/collection/search/437292)
+- Colorblind-Friendly
+***
+
+### Pissaro
+![Pissaro](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Pissaro.png)
+- Washerwoman, Study, 1880, Camille Pissarro, French, [Link](https://www.metmuseum.org/art/collection/search/437303)
+***
+
+### Redon
+![Redon](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Redon.png)
+- Pandora, 1914, Odilon Redon, French, [Link](https://www.metmuseum.org/art/collection/search/437383)
+***
+
+### Renoir
+![Renoir](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Renoir.png)
+- Nini in the Garden (Nini Lopez), 1876, Auguste Renoir, French, [Link](https://www.metmuseum.org/art/collection/search/438010?searchField=All&amp;sortBy=Relevance&amp;ft=Renoir&amp;offset=0&amp;rpp=20&amp;pos=8)
+***
+
+### Signac
+![Signac](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Signac.png)
+- Notre-Dame-de-la-Garde (La Bonne-Mère), Marseilles, 1905-06, Paul Signac, French, [Link](https://www.metmuseum.org/art/collection/search/437672)
+***
+
+### Tam
+![Tam](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Tam.png)
+- Dragon Robe, 1998, Vivienne Tam, American, born China, [Link](https://www.metmuseum.org/art/collection/search/113019)
+- Colorblind-Friendly
+***
+
+### Tara
+![Tara](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Tara.png)
+- Maharana Sarup Singh Inspects a Prize Stallion, 1845–46, Tara, Western India, Rajasthan, Mewar, [Link](https://www.metmuseum.org/art/collection/search/61429)
+***
+
+### Thomas
+![Thomas](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Thomas.png)
+- Formes et couleurs: vingt planches en couleurs contenant soixante-sept motifs decoratifs, 1921, Auguste H. Thomas, French, [Link](https://www.metmuseum.org/art/collection/search/591870?searchField=All&amp;sortBy=Relevance&amp;ft=art+deco&amp;offset=0&amp;rpp=20&amp;pos=11)
+***
+
+### Tiepolo
+![Tiepolo](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Tiepolo.png)
+- The Glorification of the Barbaro Family, 1750, Giovanni Battista Tiepolo, Italian, [Link](https://www.metmuseum.org/art/collection/search/437798)
+***
+
+### Troy
+![Troy](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Troy.png)
+- The Declaration of Love, 1724, Jean François de Troy, French, [Link](https://www.metmuseum.org/art/collection/search/438127)
+- Colorblind-Friendly
+***
+
+### Tsimshian
+![Tsimshian](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Tsimshian.png)
+- Headdress frontlet, 1820–40, Tsimshian, Native American (Canadian), [Link](https://www.metmuseum.org/art/collection/search/717587)
+***
+
+### VanGogh1
+![VanGogh1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/VanGogh1.png)
+- Cypresses, 1889, Vincent van Gogh, Dutch, [Link](https://www.metmuseum.org/art/collection/search/437980)
+***
+
+### VanGogh2
+![VanGogh2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/VanGogh2.png)
+- Self-Portrait with a Straw Hat (obverse: The Potato Peeler), 1887, Vincent van Gogh, Dutch, [Link](https://www.metmuseum.org/art/collection/search/436532)
+***
+
+### VanGogh3
+![VanGogh3](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/VanGogh3%20(Update).png)
+- First Steps, after Millet, 1890, Vincent van Gogh, Dutch, [Link](https://www.metmuseum.org/art/collection/search/436526)
+- Colorblind-Friendly
+***
+
+### Veronese
+![Veronese](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Veronese.png)
+- Mars and Venus United by Love, 1570s, Paolo Veronese, Italian, [Link](https://www.metmuseum.org/art/collection/search/437891)
+- Colorblind-Friendly
+***
+
+### Wissing
+![Wissing](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Wissing.png)
+- Portrait of a Woman, 1687, Willem Wissing, Dutch, [Link](https://www.metmuseum.org/art/collection/search/437945)
+
+
+## Functions
+```r
+You can retrieve palettes using various methods listed below.
+
+Python
+met_brew(name="VanGogh1", n=7, brew_type="discrete")
+
+R
+met.brewer(name="VanGogh1", n=7, type="discrete")
+```
+![Ex1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%201.png)
+
+```r
+Python
+met_brew(name="Manet", n=5)
+
+R
+met.brewer("Manet", 5)
+```
+![Ex2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%202.png)
+
+
+```r
+Python
+met_brew("Morgenstern")
+
+R
+met.brewer("Morgenstern")
+```
+![Ex3](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%203%20(Update).png)
+
+
+```r
+Python
+met_brew("Troy", n=15, brew_type="continuous")
+
+R
+met.brewer("Troy", n=15, type="continuous")
+```
+![Ex4](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%204.png)
+
+```r
+Python
+met_brew("Hokusai1", n=100, brew_type="continuous")
+
+R
+met.brewer("Hokusai1", n=100)
+```
+![Ex5](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example5.png)
+
+### ggplot2 Examples
+
+Here are also some ways you can incorporate this package into {ggplot2}
+
+```r
+ggplot(data=iris, aes(x=Species, y=Petal.Length, fill=Species)) +
+  geom_violin() +
+  scale_fill_manual(values=met.brewer("Greek", 3))
+```
+![Ex6](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/FillExample.png)
+
+```r
+ggplot(data=iris, aes(x=Sepal.Length, y=Sepal.Width, color=Species)) +
+  geom_point(size=2) +
+  scale_color_manual(values=met.brewer("Renoir", 3))
+```
+![Ex7](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/ColorExample.png)
+
+```r
+ggplot(data=iris, aes(x=Species, y=Sepal.Width, color=Sepal.Width)) +
+  geom_point(size=3) +
+  scale_color_gradientn(colors=met.brewer("Isfahan1"))
+```
+![Ex8](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/GradientColorExample.png)
+
+```r
+library(urbnmapr)
+countydata %>%
+  left_join(counties, by = "county_fips") %>%
+  filter(state_name =="Nebraska") %>%
+  ggplot(mapping=aes(long,lat,group = group, fill = horate)) +
+  geom_polygon(color="black",size=.25) +
+  scale_fill_gradientn(colors = met.brewer("Morgenstern")) +
+  coord_fixed() +
+  labs(fill="Homeownership rate") +
+  theme_void()
+```
+![Ex9](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/GradientFillExample%20(Update).png)
+
+
+## Colorblind Friendly Checking
+The package has been updated to check for colorblind-friendlyness
+You can list out the colorblind-friendly palettes with the following code
+```r
+Python
+for palette_name, palette_dict in COLORBLIND_PALETTES.items():
+    print(palette_name)
+
+[1] Cassatt1, Cassatt2, Derain, Egypt, Greek, Hiroshige, Hokusai2, Hokusai3, Ingres
+[2] Isfahan1, Isfahan2, Morgenstern, OKeeffe1, OKeeffe2, Pillement, Troy, VanGogh3, Veronese
+
+R
+MetBrewer::colorblind_palettes
+
+ [1] "Archambault" "Cassatt1"    "Cassatt2"    "Demuth"      "Derain"      "Egypt"       "Greek"       "Hiroshige"
+ [9] "Hokusai2"    "Hokusai3"    "Ingres"      "Isfahan1"    "Isfahan2"    "Java"        "Johnson"     "Kandinsky"
+[17] "Morgenstern" "OKeeffe1"    "OKeeffe2"    "Pillement"   "Tam"         "Troy"        "VanGogh3"    "Veronese"
+```
+
+You can also test if a palette is colorblind friendly using the function provided
+
+```r
+Python
+is_colorblind_friendly("Ingres")
+[1] True
+
+R
+MetBrewer::colorblind.friendly("Ingres")
+[1] TRUE
+```

--- a/Python/README.md
+++ b/Python/README.md
@@ -398,18 +398,20 @@ Here are also some ways you can incorporate this package into {ggplot2}
 ## Colorblind Friendly Checking
 The package has been updated to check for colorblind-friendlyness
 You can list out the colorblind-friendly palettes with the following code
-```r
-Python
+```python
 for palette_name, palette_dict in COLORBLIND_PALETTES.items():
     print(palette_name)
-
-[1] Cassatt1, Cassatt2, Derain, Egypt, Greek, Hiroshige, Hokusai2, Hokusai3, Ingres
-[2] Isfahan1, Isfahan2, Morgenstern, OKeeffe1, OKeeffe2, Pillement, Troy, VanGogh3, Veronese
+```
+```bash
+> Cassatt1, Cassatt2, Derain, Egypt, Greek, Hiroshige, Hokusai2, Hokusai3, Ingres
+> Isfahan1, Isfahan2, Morgenstern, OKeeffe1, OKeeffe2, Pillement, Troy, VanGogh3, Veronese
 ```
 
 You can also test if a palette is colorblind friendly using the function provided
 
 ```python
 is_colorblind_friendly("Ingres")
-[1] True
+```
+```bash
+> True
 ```

--- a/Python/README.md
+++ b/Python/README.md
@@ -20,17 +20,6 @@ My Website: [here](https://www.blakerobertmills.com)<br /> Twitter: [here](https
   - [Colorblind Friendly Checking](#colorblind-friendly-checking)
 
 ## Install Package
-### R
-MetBrewer is now able to be downloaded directly through R. You can still download through GitHub as well.
-
-```r
-install.packages("MetBrewer")
-
-install.packages("devtools")
-devtools::install_github("BlakeRMills/MetBrewer")
-```
-
-### Python
 Install via PyPA:
 ```
 pip install met-brewer
@@ -365,52 +354,31 @@ Kleine Welten IV (Small Worlds IV), 1922, Vasily Kandinsky, French, born Russia,
 
 
 ## Functions
-```r
 You can retrieve palettes using various methods listed below.
 
-Python
+```python
 met_brew(name="VanGogh1", n=7, brew_type="discrete")
-
-R
-met.brewer(name="VanGogh1", n=7, type="discrete")
 ```
 ![Ex1](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%201.png)
 
-```r
-Python
+```python
 met_brew(name="Manet", n=5)
-
-R
-met.brewer("Manet", 5)
 ```
 ![Ex2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%202.png)
 
 
-```r
-Python
+```python
 met_brew("Morgenstern")
-
-R
-met.brewer("Morgenstern")
 ```
 ![Ex3](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%203%20(Update).png)
 
-
-```r
-Python
+```python
 met_brew("Troy", n=15, brew_type="continuous")
-
-R
-met.brewer("Troy", n=15, type="continuous")
 ```
 ![Ex4](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example%204.png)
 
-```r
-Python
+```python
 met_brew("Hokusai1", n=100, brew_type="continuous")
-
-R
-met.brewer("Hokusai1", n=100)
 ```
 ![Ex5](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/Example5.png)
 
@@ -418,39 +386,12 @@ met.brewer("Hokusai1", n=100)
 
 Here are also some ways you can incorporate this package into {ggplot2}
 
-```r
-ggplot(data=iris, aes(x=Species, y=Petal.Length, fill=Species)) +
-  geom_violin() +
-  scale_fill_manual(values=met.brewer("Greek", 3))
-```
 ![Ex6](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/FillExample.png)
 
-```r
-ggplot(data=iris, aes(x=Sepal.Length, y=Sepal.Width, color=Species)) +
-  geom_point(size=2) +
-  scale_color_manual(values=met.brewer("Renoir", 3))
-```
 ![Ex7](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/ColorExample.png)
 
-```r
-ggplot(data=iris, aes(x=Species, y=Sepal.Width, color=Sepal.Width)) +
-  geom_point(size=3) +
-  scale_color_gradientn(colors=met.brewer("Isfahan1"))
-```
 ![Ex8](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/GradientColorExample.png)
 
-```r
-library(urbnmapr)
-countydata %>%
-  left_join(counties, by = "county_fips") %>%
-  filter(state_name =="Nebraska") %>%
-  ggplot(mapping=aes(long,lat,group = group, fill = horate)) +
-  geom_polygon(color="black",size=.25) +
-  scale_fill_gradientn(colors = met.brewer("Morgenstern")) +
-  coord_fixed() +
-  labs(fill="Homeownership rate") +
-  theme_void()
-```
 ![Ex9](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/GradientFillExample%20(Update).png)
 
 
@@ -464,23 +405,11 @@ for palette_name, palette_dict in COLORBLIND_PALETTES.items():
 
 [1] Cassatt1, Cassatt2, Derain, Egypt, Greek, Hiroshige, Hokusai2, Hokusai3, Ingres
 [2] Isfahan1, Isfahan2, Morgenstern, OKeeffe1, OKeeffe2, Pillement, Troy, VanGogh3, Veronese
-
-R
-MetBrewer::colorblind_palettes
-
- [1] "Archambault" "Cassatt1"    "Cassatt2"    "Demuth"      "Derain"      "Egypt"       "Greek"       "Hiroshige"
- [9] "Hokusai2"    "Hokusai3"    "Ingres"      "Isfahan1"    "Isfahan2"    "Java"        "Johnson"     "Kandinsky"
-[17] "Morgenstern" "OKeeffe1"    "OKeeffe2"    "Pillement"   "Tam"         "Troy"        "VanGogh3"    "Veronese"
 ```
 
 You can also test if a palette is colorblind friendly using the function provided
 
-```r
-Python
+```python
 is_colorblind_friendly("Ingres")
 [1] True
-
-R
-MetBrewer::colorblind.friendly("Ingres")
-[1] TRUE
 ```

--- a/Python/met_brewer/__init__.py
+++ b/Python/met_brewer/__init__.py
@@ -1,6 +1,10 @@
 from met_brewer.palettes import (
-    MET_PALETTES, COLORBLIND_PALETTES_NAMES, COLORBLIND_PALETTES,
-    met_brew, export, is_colorblind_friendly
+    MET_PALETTES,
+    COLORBLIND_PALETTES_NAMES,
+    COLORBLIND_PALETTES,
+    met_brew,
+    export,
+    is_colorblind_friendly,
 )
 
 

--- a/Python/met_brewer/palettes.py
+++ b/Python/met_brewer/palettes.py
@@ -2,73 +2,691 @@ from colour import Color
 from matplotlib.colors import LinearSegmentedColormap, to_hex
 
 MET_PALETTES = dict(
-    Archambault=dict(colors=("#88a0dc", "#381a61", "#7c4b73", "#ed968c", "#ab3329", "#e78429", "#f9d14a"), order=(2, 7, 5, 1, 6, 4, 3), colorblind=True),
-    Austria=dict(colors=("#a40000", "#16317d", "#007e2f", "#ffcd12", "#b86092", "#721b3e", "#00b7a7"), order=(1, 2, 3, 4, 6, 5, 7), colorblind=False),
-    Benedictus = dict(colors=("#9a133d", "#b93961", "#d8527c", "#f28aaa", "#f9b4c9", "#f9e0e8", "#ffffff", "#eaf3ff", "#c5daf6", "#a1c2ed", "#6996e3", "#4060c8", "#1a318b"), order=(9, 5, 11, 1, 7, 3, 13, 4, 8, 2, 12, 6, 10), colorblind=False),
-    Cassatt1=dict(colors=("#b1615c", "#d88782", "#e3aba7", "#edd7d9", "#c9c9dd", "#9d9dc7", "#8282aa", "#5a5a83"), order=(3, 6, 1, 8, 4, 5, 2, 7), colorblind=True),
-    Cassatt2=dict(colors=("#2d223c", "#574571", "#90719f", "#b695bc", "#dec5da", "#c1d1aa", "#7fa074", "#466c4b", "#2c4b27", "#0e2810"), order=(7, 3, 9, 1, 5, 6, 2, 10, 4, 8), colorblind=True),
-    Cross=dict(colors=("#c969a1", "#ce4441", "#ee8577", "#eb7926", "#ffbb44", "#859b6c", "#62929a", "#004f63", "#122451"), order=(4, 7, 1, 8, 2, 6, 3, 5, 9), colorblind=False),
-    Degas=dict(colors=("#591d06", "#96410e", "#e5a335", "#556219", "#418979", "#2b614e", "#053c29"), order=(5, 2, 1, 3, 4, 7, 6), colorblind=False),
-    Demuth = dict(colors=("#591c19", "#9b332b", "#b64f32", "#d39a2d", "#f7c267", "#b9b9b8", "#8b8b99", "#5d6174", "#41485f", "#262d42"), order=(9, 5, 1, 7, 3, 4, 8, 2, 6, 10), colorblind=True),
-    Derain=dict(colors=("#efc86e", "#97c684", "#6f9969", "#aab5d5", "#808fe1", "#5c66a8", "#454a74"), order=(4, 2, 5, 7, 1, 3, 6), colorblind=True),
-    Egypt=dict(colors=("#dd5129", "#0f7ba2", "#43b284", "#fab255"), order=(1, 2, 3, 4), colorblind=True),
-    Gauguin=dict(colors=("#b04948", "#811e18", "#9e4013", "#c88a2c", "#4c6216", "#1a472a"), order=(2, 5, 4, 3, 1, 6), colorblind=False),
-    Greek=dict(colors=("#3c0d03", "#8d1c06", "#e67424", "#ed9b49", "#f5c34d"), order=(2, 3, 5, 1, 4), colorblind=True),
-    Hiroshige=dict(colors=("#e76254", "#ef8a47", "#f7aa58", "#ffd06f", "#ffe6b7", "#aadce0", "#72bcd5", "#528fad", "#376795", "#1e466e"), order=(6, 2, 9, 3, 7, 5, 1, 10, 4, 8), colorblind=True),
-    Hokusai1=dict(colors=("#6d2f20", "#b75347", "#df7e66", "#e09351", "#edc775", "#94b594", "#224b5e"), order=(2, 7, 4, 6, 5, 1, 3), colorblind=False),
-    Hokusai2=dict(colors=("#abc9c8", "#72aeb6", "#4692b0", "#2f70a1", "#134b73", "#0a3351"), order=(5, 2, 4, 1, 6, 3), colorblind=True),
-    Hokusai3=dict(colors=("#d8d97a", "#95c36e", "#74c8c3", "#5a97c1", "#295384", "#0a2e57"), order=(4, 2, 5, 3, 1, 6), colorblind=True),
-    Homer1=dict(colors=("#551f00", "#a62f00", "#df7700", "#f5b642", "#fff179", "#c3f4f6", "#6ad5e8", "#32b2da"), order=(6, 3, 2, 7, 4, 8, 5, 1), colorblind=False),
-    Homer2=dict(colors=("#bf3626", "#e9724c", "#e9851d", "#f9c53b", "#aeac4c", "#788f33", "#165d43"), order=(3, 7, 1, 4, 6, 2, 5), colorblind=False),
-    Ingres=dict(colors=("#041d2c", "#06314e", "#18527e", "#2e77ab", "#d1b252", "#a97f2f", "#7e5522", "#472c0b"), order=(4, 5, 3, 6, 2, 7, 1, 8), colorblind=True),
-    Isfahan1=dict(colors=("#4e3910", "#845d29", "#d8c29d", "#4fb6ca", "#178f92", "#175f5d", "#1d1f54"), order=(5, 2, 4, 6, 1, 7, 3), colorblind=True),
-    Isfahan2=dict(colors=("#d7aca1", "#ddc000", "#79ad41", "#34b6c6", "#4063a3"), order=(4, 2, 3, 5, 1), colorblind=True),
-    Java = dict(colors=("#663171", "#cf3a36", "#ea7428", "#e2998a", "#0c7156"), order=(1, 4, 2, 5, 3), colorblind=True),
-    Johnson = dict(colors=("#a00e00", "#d04e00", "#f6c200", "#0086a8", "#132b69"), order=(3, 1, 4, 2, 5), colorblind=True),
-    Juarez=dict(colors=("#a82203", "#208cc0", "#f1af3a", "#cf5e4e", "#637b31", "#003967"), order=(1, 2, 3, 4, 5, 6), colorblind=False),
-    Kandinsky = dict(colors=("#3b7c70", "#ce9642", "#898e9f", "#3b3a3e"), order=(1, 2, 3, 4), colorblind=True),
-    Klimt=dict(colors=("#df9ed4", "#c93f55", "#eacc62", "#469d76", "#3c4b99", "#924099"), order=(5, 2, 3, 4, 6, 1), colorblind=False),
-    Lakota=dict(colors=("#04a3bd", "#f0be3d", "#931e18", "#da7901", "#247d3f", "#20235b"), order=(1, 2, 3, 4, 5, 6), colorblind=False),
-    Manet=dict(colors=("#3b2319", "#80521c", "#d29c44", "#ebc174", "#ede2cc", "#7ec5f4", "#4585b7", "#225e92", "#183571", "#43429b", "#5e65be"), order=(8, 3, 10, 4, 7, 9, 11, 2, 6, 1, 5), colorblind=False),
-    Monet=dict(colors=("#4e6d58", "#749e89", "#abccbe", "#e3cacf", "#c399a2", "#9f6e71", "#41507b", "#7d87b2", "#c2cae3"), order=(2, 5, 8, 3, 4, 9, 1, 6, 7), colorblind=False),
-    Moreau=dict(colors=("#421600", "#792504", "#bc7524", "#8dadca", "#527baa", "#104839", "#082844"), order=(2, 5, 3, 4, 7, 1, 6), colorblind=False),
-    Morgenstern=dict(colors=("#7c668c", "#b08ba5", "#dfbbc8", "#ffc680", "#ffb178", "#db8872", "#a56457"), order=(7, 5, 4, 6, 3, 2, 1), colorblind=True),
-    Nattier=dict(colors=("#52271c", "#944839", "#c08e39", "#7f793c", "#565c33", "#184948", "#022a2a"), order=(1, 6, 3, 4, 7, 2, 5), colorblind=False),
-    Navajo=dict(colors=("#660d20", "#e59a52", "#edce79", "#094568", "#e1c59a"), order=(1, 2, 3, 4, 5), colorblind=False),
-    NewKingdom=dict(colors=("#e1846c", "#9eb4e0", "#e6bb9e", "#9c6849", "#735852"), order=(2, 1, 3, 4, 5), colorblind=False),
-    Nizami=dict(colors=("#dd7867", "#b83326", "#c8570d", "#edb144", "#8cc8bc", "#7da7ea", "#5773c0", "#1d4497"), order=(5, 2, 6, 8, 3, 7, 4, 1), colorblind=False),
-    OKeeffe1=dict(colors=("#6b200c", "#973d21", "#da6c42", "#ee956a", "#fbc2a9", "#f6f2ee", "#bad6f9", "#7db0ea", "#447fdd", "#225bb2", "#133e7e"), order=(8, 6, 1, 4, 10, 3, 11, 5, 2, 7, 9), colorblind=True),
-    OKeeffe2=dict(colors=("#fbe3c2", "#f2c88f", "#ecb27d", "#e69c6b", "#d37750", "#b9563f", "#92351e"), order=(7, 1, 6, 4, 2, 5, 3), colorblind=True),
-    Paquin = dict(colors=("#831818", "#c62320", "#f05b43", "#f78462", "#feac81", "#f7dea3", "#ced1af", "#98ab76", "#748f46", "#47632a", "#275024"), order=(10, 6, 1, 8, 4, 3, 5, 9, 2, 7, 11), colorblind=False),
-    Peru1=dict(colors=("#b5361c", "#e35e28", "#1c9d7c", "#31c7ba", "#369cc9", "#3a507f"), order=(3, 1, 5, 2, 4, 6), colorblind=False),
-    Peru2=dict(colors=("#65150b", "#961f1f", "#c0431f", "#b36c06", "#f19425", "#c59349", "#533d14"), order=(4, 1, 3, 5, 2, 7, 6), colorblind=False),
-    Pillement=dict(colors=("#a9845b", "#697852", "#738e8e", "#44636f", "#2b4655", "#0f252f"), order=(4, 3, 2, 5, 1, 6), colorblind=True),
-    Pissaro=dict(colors=("#134130", "#4c825d", "#8cae9e", "#8dc7dc", "#508ca7", "#1a5270", "#0e2a4d"), order=(6, 2, 4, 1, 7, 5, 3), colorblind=False),
-    Redon=dict(colors=("#5b859e", "#1e395f", "#75884b", "#1e5a46", "#df8d71", "#af4f2f", "#d48f90", "#732f30", "#ab84a5", "#59385c", "#d8b847", "#b38711"), order=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12), colorblind=False),
-    Renoir=dict(colors=("#17154f", "#2f357c", "#6c5d9e", "#9d9cd5", "#b0799a", "#f6b3b0", "#e48171", "#bf3729", "#e69b00", "#f5bb50", "#ada43b", "#355828"), order=(2, 5, 9, 12, 3, 8, 7, 10, 4, 1, 6, 11), colorblind=False),
-    Robert=dict(colors=("#11341a", "#375624", "#6ca4a0", "#487a7c", "#18505f", "#062e3d"), order=(2, 5, 3, 1, 6, 4), colorblind=False),
-    Signac=dict(colors=("#fbe183", "#f4c40f", "#fe9b00", "#d8443c", "#9b3441", "#de597c", "#e87b89", "#e6a2a6", "#aa7aa1", "#9f5691", "#633372", "#1f6e9c", "#2b9b81", "#92c051"), order=(13, 3, 2, 1, 11, 5, 8, 14, 12, 10, 7, 4, 6, 9), colorblind=False),
-    Stevens=dict(colors=("#042e4e", "#307d7f", "#598c4c", "#ba5c3f", "#a13213", "#470c00"), order=(4, 2, 3, 5, 1, 6), colorblind=False),
-    Tam = dict(colors=("#ffd353", "#ffb242", "#ef8737", "#de4f33", "#bb292c", "#9f2d55", "#62205f", "#341648"), order=(3, 8, 1, 6, 2, 7, 4, 5), colorblind=True),
-    Tara=dict(colors=("#eab1c6", "#d35e17", "#e18a1f", "#e9b109", "#829d44"), order=(1, 3, 2, 5, 4), colorblind=False),
-    Thomas=dict(colors=("#b24422", "#c44d76", "#4457a5", "#13315f", "#b1a1cc", "#59386c", "#447861", "#7caf5c"), order=(3, 2, 8, 6, 1, 4, 7, 5), colorblind=False),
-    Tiepolo=dict(colors=("#802417", "#c06636", "#ce9344", "#e8b960", "#646e3b", "#2b5851", "#508ea2", "#17486f"), order=(1, 2, 8, 4, 3, 5, 7, 6), colorblind=False),
-    Troy=dict(colors=("#421401", "#6c1d0e", "#8b3a2b", "#c27668", "#7ba0b4", "#44728c", "#235070", "#0a2d46"), order=(2, 7, 4, 5, 1, 8, 3, 6), colorblind=True),
-    Tsimshian=dict(colors=("#582310", "#aa361d", "#82c45f", "#318f49", "#0cb4bb", "#2673a3", "#473d7d"), order=(6, 1, 7, 4, 1, 5, 3), colorblind=False),
-    VanGogh1=dict(colors=("#2c2d54", "#434475", "#6b6ca3", "#969bc7", "#87bcbd", "#89ab7c", "#6f9954"), order=(3, 5, 7, 4, 6, 2, 1), colorblind=False),
-    VanGogh2=dict(colors=("#bd3106", "#d9700e", "#e9a00e", "#eebe04", "#5b7314", "#c3d6ce", "#89a6bb", "#454b87"), order=(1, 5, 8, 2, 7, 4, 6, 3), colorblind=False),
-    VanGogh3=dict(colors=("#e7e5cc", "#c2d6a4", "#9cc184", "#669d62", "#447243", "#1f5b25", "#1e3d14", "#192813"), order=(7, 5, 1, 4, 8, 2, 3, 6), colorblind=True),
-    Veronese=dict(colors=("#67322e", "#99610a", "#c38f16", "#6e948c", "#2c6b67", "#175449", "#122c43"), order=(5, 1, 7, 2, 3, 6, 4), colorblind=True),
-    Wissing=dict(colors=("#4b1d0d", "#7c291e", "#ba7233", "#3a4421", "#2d5380"), order=(2, 3, 5, 4, 1), colorblind=False)
-  )
+    Archambault=dict(
+        colors=(
+            "#88a0dc",
+            "#381a61",
+            "#7c4b73",
+            "#ed968c",
+            "#ab3329",
+            "#e78429",
+            "#f9d14a",
+        ),
+        order=(2, 7, 5, 1, 6, 4, 3),
+        colorblind=True,
+    ),
+    Austria=dict(
+        colors=(
+            "#a40000",
+            "#16317d",
+            "#007e2f",
+            "#ffcd12",
+            "#b86092",
+            "#721b3e",
+            "#00b7a7",
+        ),
+        order=(1, 2, 3, 4, 6, 5, 7),
+        colorblind=False,
+    ),
+    Benedictus=dict(
+        colors=(
+            "#9a133d",
+            "#b93961",
+            "#d8527c",
+            "#f28aaa",
+            "#f9b4c9",
+            "#f9e0e8",
+            "#ffffff",
+            "#eaf3ff",
+            "#c5daf6",
+            "#a1c2ed",
+            "#6996e3",
+            "#4060c8",
+            "#1a318b",
+        ),
+        order=(9, 5, 11, 1, 7, 3, 13, 4, 8, 2, 12, 6, 10),
+        colorblind=False,
+    ),
+    Cassatt1=dict(
+        colors=(
+            "#b1615c",
+            "#d88782",
+            "#e3aba7",
+            "#edd7d9",
+            "#c9c9dd",
+            "#9d9dc7",
+            "#8282aa",
+            "#5a5a83",
+        ),
+        order=(3, 6, 1, 8, 4, 5, 2, 7),
+        colorblind=True,
+    ),
+    Cassatt2=dict(
+        colors=(
+            "#2d223c",
+            "#574571",
+            "#90719f",
+            "#b695bc",
+            "#dec5da",
+            "#c1d1aa",
+            "#7fa074",
+            "#466c4b",
+            "#2c4b27",
+            "#0e2810",
+        ),
+        order=(7, 3, 9, 1, 5, 6, 2, 10, 4, 8),
+        colorblind=True,
+    ),
+    Cross=dict(
+        colors=(
+            "#c969a1",
+            "#ce4441",
+            "#ee8577",
+            "#eb7926",
+            "#ffbb44",
+            "#859b6c",
+            "#62929a",
+            "#004f63",
+            "#122451",
+        ),
+        order=(4, 7, 1, 8, 2, 6, 3, 5, 9),
+        colorblind=False,
+    ),
+    Degas=dict(
+        colors=(
+            "#591d06",
+            "#96410e",
+            "#e5a335",
+            "#556219",
+            "#418979",
+            "#2b614e",
+            "#053c29",
+        ),
+        order=(5, 2, 1, 3, 4, 7, 6),
+        colorblind=False,
+    ),
+    Demuth=dict(
+        colors=(
+            "#591c19",
+            "#9b332b",
+            "#b64f32",
+            "#d39a2d",
+            "#f7c267",
+            "#b9b9b8",
+            "#8b8b99",
+            "#5d6174",
+            "#41485f",
+            "#262d42",
+        ),
+        order=(9, 5, 1, 7, 3, 4, 8, 2, 6, 10),
+        colorblind=True,
+    ),
+    Derain=dict(
+        colors=(
+            "#efc86e",
+            "#97c684",
+            "#6f9969",
+            "#aab5d5",
+            "#808fe1",
+            "#5c66a8",
+            "#454a74",
+        ),
+        order=(4, 2, 5, 7, 1, 3, 6),
+        colorblind=True,
+    ),
+    Egypt=dict(
+        colors=("#dd5129", "#0f7ba2", "#43b284", "#fab255"),
+        order=(1, 2, 3, 4),
+        colorblind=True,
+    ),
+    Gauguin=dict(
+        colors=("#b04948", "#811e18", "#9e4013", "#c88a2c", "#4c6216", "#1a472a"),
+        order=(2, 5, 4, 3, 1, 6),
+        colorblind=False,
+    ),
+    Greek=dict(
+        colors=("#3c0d03", "#8d1c06", "#e67424", "#ed9b49", "#f5c34d"),
+        order=(2, 3, 5, 1, 4),
+        colorblind=True,
+    ),
+    Hiroshige=dict(
+        colors=(
+            "#e76254",
+            "#ef8a47",
+            "#f7aa58",
+            "#ffd06f",
+            "#ffe6b7",
+            "#aadce0",
+            "#72bcd5",
+            "#528fad",
+            "#376795",
+            "#1e466e",
+        ),
+        order=(6, 2, 9, 3, 7, 5, 1, 10, 4, 8),
+        colorblind=True,
+    ),
+    Hokusai1=dict(
+        colors=(
+            "#6d2f20",
+            "#b75347",
+            "#df7e66",
+            "#e09351",
+            "#edc775",
+            "#94b594",
+            "#224b5e",
+        ),
+        order=(2, 7, 4, 6, 5, 1, 3),
+        colorblind=False,
+    ),
+    Hokusai2=dict(
+        colors=("#abc9c8", "#72aeb6", "#4692b0", "#2f70a1", "#134b73", "#0a3351"),
+        order=(5, 2, 4, 1, 6, 3),
+        colorblind=True,
+    ),
+    Hokusai3=dict(
+        colors=("#d8d97a", "#95c36e", "#74c8c3", "#5a97c1", "#295384", "#0a2e57"),
+        order=(4, 2, 5, 3, 1, 6),
+        colorblind=True,
+    ),
+    Homer1=dict(
+        colors=(
+            "#551f00",
+            "#a62f00",
+            "#df7700",
+            "#f5b642",
+            "#fff179",
+            "#c3f4f6",
+            "#6ad5e8",
+            "#32b2da",
+        ),
+        order=(6, 3, 2, 7, 4, 8, 5, 1),
+        colorblind=False,
+    ),
+    Homer2=dict(
+        colors=(
+            "#bf3626",
+            "#e9724c",
+            "#e9851d",
+            "#f9c53b",
+            "#aeac4c",
+            "#788f33",
+            "#165d43",
+        ),
+        order=(3, 7, 1, 4, 6, 2, 5),
+        colorblind=False,
+    ),
+    Ingres=dict(
+        colors=(
+            "#041d2c",
+            "#06314e",
+            "#18527e",
+            "#2e77ab",
+            "#d1b252",
+            "#a97f2f",
+            "#7e5522",
+            "#472c0b",
+        ),
+        order=(4, 5, 3, 6, 2, 7, 1, 8),
+        colorblind=True,
+    ),
+    Isfahan1=dict(
+        colors=(
+            "#4e3910",
+            "#845d29",
+            "#d8c29d",
+            "#4fb6ca",
+            "#178f92",
+            "#175f5d",
+            "#1d1f54",
+        ),
+        order=(5, 2, 4, 6, 1, 7, 3),
+        colorblind=True,
+    ),
+    Isfahan2=dict(
+        colors=("#d7aca1", "#ddc000", "#79ad41", "#34b6c6", "#4063a3"),
+        order=(4, 2, 3, 5, 1),
+        colorblind=True,
+    ),
+    Java=dict(
+        colors=("#663171", "#cf3a36", "#ea7428", "#e2998a", "#0c7156"),
+        order=(1, 4, 2, 5, 3),
+        colorblind=True,
+    ),
+    Johnson=dict(
+        colors=("#a00e00", "#d04e00", "#f6c200", "#0086a8", "#132b69"),
+        order=(3, 1, 4, 2, 5),
+        colorblind=True,
+    ),
+    Juarez=dict(
+        colors=("#a82203", "#208cc0", "#f1af3a", "#cf5e4e", "#637b31", "#003967"),
+        order=(1, 2, 3, 4, 5, 6),
+        colorblind=False,
+    ),
+    Kandinsky=dict(
+        colors=("#3b7c70", "#ce9642", "#898e9f", "#3b3a3e"),
+        order=(1, 2, 3, 4),
+        colorblind=True,
+    ),
+    Klimt=dict(
+        colors=("#df9ed4", "#c93f55", "#eacc62", "#469d76", "#3c4b99", "#924099"),
+        order=(5, 2, 3, 4, 6, 1),
+        colorblind=False,
+    ),
+    Lakota=dict(
+        colors=("#04a3bd", "#f0be3d", "#931e18", "#da7901", "#247d3f", "#20235b"),
+        order=(1, 2, 3, 4, 5, 6),
+        colorblind=False,
+    ),
+    Manet=dict(
+        colors=(
+            "#3b2319",
+            "#80521c",
+            "#d29c44",
+            "#ebc174",
+            "#ede2cc",
+            "#7ec5f4",
+            "#4585b7",
+            "#225e92",
+            "#183571",
+            "#43429b",
+            "#5e65be",
+        ),
+        order=(8, 3, 10, 4, 7, 9, 11, 2, 6, 1, 5),
+        colorblind=False,
+    ),
+    Monet=dict(
+        colors=(
+            "#4e6d58",
+            "#749e89",
+            "#abccbe",
+            "#e3cacf",
+            "#c399a2",
+            "#9f6e71",
+            "#41507b",
+            "#7d87b2",
+            "#c2cae3",
+        ),
+        order=(2, 5, 8, 3, 4, 9, 1, 6, 7),
+        colorblind=False,
+    ),
+    Moreau=dict(
+        colors=(
+            "#421600",
+            "#792504",
+            "#bc7524",
+            "#8dadca",
+            "#527baa",
+            "#104839",
+            "#082844",
+        ),
+        order=(2, 5, 3, 4, 7, 1, 6),
+        colorblind=False,
+    ),
+    Morgenstern=dict(
+        colors=(
+            "#7c668c",
+            "#b08ba5",
+            "#dfbbc8",
+            "#ffc680",
+            "#ffb178",
+            "#db8872",
+            "#a56457",
+        ),
+        order=(7, 5, 4, 6, 3, 2, 1),
+        colorblind=True,
+    ),
+    Nattier=dict(
+        colors=(
+            "#52271c",
+            "#944839",
+            "#c08e39",
+            "#7f793c",
+            "#565c33",
+            "#184948",
+            "#022a2a",
+        ),
+        order=(1, 6, 3, 4, 7, 2, 5),
+        colorblind=False,
+    ),
+    Navajo=dict(
+        colors=("#660d20", "#e59a52", "#edce79", "#094568", "#e1c59a"),
+        order=(1, 2, 3, 4, 5),
+        colorblind=False,
+    ),
+    NewKingdom=dict(
+        colors=("#e1846c", "#9eb4e0", "#e6bb9e", "#9c6849", "#735852"),
+        order=(2, 1, 3, 4, 5),
+        colorblind=False,
+    ),
+    Nizami=dict(
+        colors=(
+            "#dd7867",
+            "#b83326",
+            "#c8570d",
+            "#edb144",
+            "#8cc8bc",
+            "#7da7ea",
+            "#5773c0",
+            "#1d4497",
+        ),
+        order=(5, 2, 6, 8, 3, 7, 4, 1),
+        colorblind=False,
+    ),
+    OKeeffe1=dict(
+        colors=(
+            "#6b200c",
+            "#973d21",
+            "#da6c42",
+            "#ee956a",
+            "#fbc2a9",
+            "#f6f2ee",
+            "#bad6f9",
+            "#7db0ea",
+            "#447fdd",
+            "#225bb2",
+            "#133e7e",
+        ),
+        order=(8, 6, 1, 4, 10, 3, 11, 5, 2, 7, 9),
+        colorblind=True,
+    ),
+    OKeeffe2=dict(
+        colors=(
+            "#fbe3c2",
+            "#f2c88f",
+            "#ecb27d",
+            "#e69c6b",
+            "#d37750",
+            "#b9563f",
+            "#92351e",
+        ),
+        order=(7, 1, 6, 4, 2, 5, 3),
+        colorblind=True,
+    ),
+    Paquin=dict(
+        colors=(
+            "#831818",
+            "#c62320",
+            "#f05b43",
+            "#f78462",
+            "#feac81",
+            "#f7dea3",
+            "#ced1af",
+            "#98ab76",
+            "#748f46",
+            "#47632a",
+            "#275024",
+        ),
+        order=(10, 6, 1, 8, 4, 3, 5, 9, 2, 7, 11),
+        colorblind=False,
+    ),
+    Peru1=dict(
+        colors=("#b5361c", "#e35e28", "#1c9d7c", "#31c7ba", "#369cc9", "#3a507f"),
+        order=(3, 1, 5, 2, 4, 6),
+        colorblind=False,
+    ),
+    Peru2=dict(
+        colors=(
+            "#65150b",
+            "#961f1f",
+            "#c0431f",
+            "#b36c06",
+            "#f19425",
+            "#c59349",
+            "#533d14",
+        ),
+        order=(4, 1, 3, 5, 2, 7, 6),
+        colorblind=False,
+    ),
+    Pillement=dict(
+        colors=("#a9845b", "#697852", "#738e8e", "#44636f", "#2b4655", "#0f252f"),
+        order=(4, 3, 2, 5, 1, 6),
+        colorblind=True,
+    ),
+    Pissaro=dict(
+        colors=(
+            "#134130",
+            "#4c825d",
+            "#8cae9e",
+            "#8dc7dc",
+            "#508ca7",
+            "#1a5270",
+            "#0e2a4d",
+        ),
+        order=(6, 2, 4, 1, 7, 5, 3),
+        colorblind=False,
+    ),
+    Redon=dict(
+        colors=(
+            "#5b859e",
+            "#1e395f",
+            "#75884b",
+            "#1e5a46",
+            "#df8d71",
+            "#af4f2f",
+            "#d48f90",
+            "#732f30",
+            "#ab84a5",
+            "#59385c",
+            "#d8b847",
+            "#b38711",
+        ),
+        order=(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+        colorblind=False,
+    ),
+    Renoir=dict(
+        colors=(
+            "#17154f",
+            "#2f357c",
+            "#6c5d9e",
+            "#9d9cd5",
+            "#b0799a",
+            "#f6b3b0",
+            "#e48171",
+            "#bf3729",
+            "#e69b00",
+            "#f5bb50",
+            "#ada43b",
+            "#355828",
+        ),
+        order=(2, 5, 9, 12, 3, 8, 7, 10, 4, 1, 6, 11),
+        colorblind=False,
+    ),
+    Robert=dict(
+        colors=("#11341a", "#375624", "#6ca4a0", "#487a7c", "#18505f", "#062e3d"),
+        order=(2, 5, 3, 1, 6, 4),
+        colorblind=False,
+    ),
+    Signac=dict(
+        colors=(
+            "#fbe183",
+            "#f4c40f",
+            "#fe9b00",
+            "#d8443c",
+            "#9b3441",
+            "#de597c",
+            "#e87b89",
+            "#e6a2a6",
+            "#aa7aa1",
+            "#9f5691",
+            "#633372",
+            "#1f6e9c",
+            "#2b9b81",
+            "#92c051",
+        ),
+        order=(13, 3, 2, 1, 11, 5, 8, 14, 12, 10, 7, 4, 6, 9),
+        colorblind=False,
+    ),
+    Stevens=dict(
+        colors=("#042e4e", "#307d7f", "#598c4c", "#ba5c3f", "#a13213", "#470c00"),
+        order=(4, 2, 3, 5, 1, 6),
+        colorblind=False,
+    ),
+    Tam=dict(
+        colors=(
+            "#ffd353",
+            "#ffb242",
+            "#ef8737",
+            "#de4f33",
+            "#bb292c",
+            "#9f2d55",
+            "#62205f",
+            "#341648",
+        ),
+        order=(3, 8, 1, 6, 2, 7, 4, 5),
+        colorblind=True,
+    ),
+    Tara=dict(
+        colors=("#eab1c6", "#d35e17", "#e18a1f", "#e9b109", "#829d44"),
+        order=(1, 3, 2, 5, 4),
+        colorblind=False,
+    ),
+    Thomas=dict(
+        colors=(
+            "#b24422",
+            "#c44d76",
+            "#4457a5",
+            "#13315f",
+            "#b1a1cc",
+            "#59386c",
+            "#447861",
+            "#7caf5c",
+        ),
+        order=(3, 2, 8, 6, 1, 4, 7, 5),
+        colorblind=False,
+    ),
+    Tiepolo=dict(
+        colors=(
+            "#802417",
+            "#c06636",
+            "#ce9344",
+            "#e8b960",
+            "#646e3b",
+            "#2b5851",
+            "#508ea2",
+            "#17486f",
+        ),
+        order=(1, 2, 8, 4, 3, 5, 7, 6),
+        colorblind=False,
+    ),
+    Troy=dict(
+        colors=(
+            "#421401",
+            "#6c1d0e",
+            "#8b3a2b",
+            "#c27668",
+            "#7ba0b4",
+            "#44728c",
+            "#235070",
+            "#0a2d46",
+        ),
+        order=(2, 7, 4, 5, 1, 8, 3, 6),
+        colorblind=True,
+    ),
+    Tsimshian=dict(
+        colors=(
+            "#582310",
+            "#aa361d",
+            "#82c45f",
+            "#318f49",
+            "#0cb4bb",
+            "#2673a3",
+            "#473d7d",
+        ),
+        order=(6, 1, 7, 4, 1, 5, 3),
+        colorblind=False,
+    ),
+    VanGogh1=dict(
+        colors=(
+            "#2c2d54",
+            "#434475",
+            "#6b6ca3",
+            "#969bc7",
+            "#87bcbd",
+            "#89ab7c",
+            "#6f9954",
+        ),
+        order=(3, 5, 7, 4, 6, 2, 1),
+        colorblind=False,
+    ),
+    VanGogh2=dict(
+        colors=(
+            "#bd3106",
+            "#d9700e",
+            "#e9a00e",
+            "#eebe04",
+            "#5b7314",
+            "#c3d6ce",
+            "#89a6bb",
+            "#454b87",
+        ),
+        order=(1, 5, 8, 2, 7, 4, 6, 3),
+        colorblind=False,
+    ),
+    VanGogh3=dict(
+        colors=(
+            "#e7e5cc",
+            "#c2d6a4",
+            "#9cc184",
+            "#669d62",
+            "#447243",
+            "#1f5b25",
+            "#1e3d14",
+            "#192813",
+        ),
+        order=(7, 5, 1, 4, 8, 2, 3, 6),
+        colorblind=True,
+    ),
+    Veronese=dict(
+        colors=(
+            "#67322e",
+            "#99610a",
+            "#c38f16",
+            "#6e948c",
+            "#2c6b67",
+            "#175449",
+            "#122c43",
+        ),
+        order=(5, 1, 7, 2, 3, 6, 4),
+        colorblind=True,
+    ),
+    Wissing=dict(
+        colors=("#4b1d0d", "#7c291e", "#ba7233", "#3a4421", "#2d5380"),
+        order=(2, 3, 5, 4, 1),
+        colorblind=False,
+    ),
+)
 
-COLORBLIND_PALETTES_NAMES = ("Archambault", "Cassatt1", "Cassatt2", "Demuth", "Derain", "Egypt", "Greek", "Hiroshige", "Hokusai2", "Hokusai3", "Ingres", "Isfahan1", "Isfahan2", "Java", "Johnson", "Kandinsky", "Morgenstern", "OKeeffe1", "OKeeffe2", "Pillement", "Tam", "Troy", "VanGogh3", "Veronese")
+COLORBLIND_PALETTES_NAMES = (
+    "Archambault",
+    "Cassatt1",
+    "Cassatt2",
+    "Demuth",
+    "Derain",
+    "Egypt",
+    "Greek",
+    "Hiroshige",
+    "Hokusai2",
+    "Hokusai3",
+    "Ingres",
+    "Isfahan1",
+    "Isfahan2",
+    "Java",
+    "Johnson",
+    "Kandinsky",
+    "Morgenstern",
+    "OKeeffe1",
+    "OKeeffe2",
+    "Pillement",
+    "Tam",
+    "Troy",
+    "VanGogh3",
+    "Veronese",
+)
 COLORBLIND_PALETTES = {name: MET_PALETTES[name] for name in COLORBLIND_PALETTES_NAMES}
 EXPORT_FORMATS = {"HEX", "DEC", "REL", "XML", "IPE"}
 
 
 def met_brew(name, n=None, brew_type="discrete"):
-
     palette = MET_PALETTES.get(name)
 
     if not brew_type or type(name) in (int, float):
@@ -78,24 +696,24 @@ def met_brew(name, n=None, brew_type="discrete"):
         n = len(palette["colors"])
         print(f"Palette '{name}' has '{n}' discrete colors")
 
-
     if brew_type not in {"discrete", "continuous"}:
         brew_type = "discrete"
 
     if brew_type == "discrete" and n > len(palette["colors"]):
-        print(f"Number of requested colors ('{n}') greater than number of colors '{name}' can offer. \n Setting brew_type to 'continuous' instead.")
+        print(
+            f"Number of requested colors ('{n}') greater than number of colors '{name}' can offer. \n"
+            f"Setting brew_type to 'continuous' instead."
+        )
         brew_type = "continuous"
 
     out = list()
     if brew_type == "continuous":
-
         colors = [Color(c).rgb for c in palette["colors"]]
         color_map = LinearSegmentedColormap.from_list(name, colors, N=n)
         for i in range(n):
             out.append(to_hex(color_map(i)))
 
     elif brew_type == "discrete":
-
         rounds = n // len(palette["colors"])
         delta = n % len(palette["colors"])
         for _ in range(rounds):
@@ -113,7 +731,6 @@ def met_brew(name, n=None, brew_type="discrete"):
 
 
 def is_colorblind_friendly(name):
-
     if name not in MET_PALETTES:
         raise Exception(f"Palette {name} does not exist.")
     else:
@@ -123,7 +740,6 @@ def is_colorblind_friendly(name):
 
 
 def export(name, format="hex"):
-
     format = format.upper()
 
     palette = MET_PALETTES.get(name)
@@ -132,43 +748,36 @@ def export(name, format="hex"):
     export = dict()
     if palette and format in EXPORT_FORMATS:
         if format == "HEX":
-            export = {
-                "name": name,
-                "colors": [c.hex for c in colors]
-            }
+            export = {"name": name, "colors": [c.hex for c in colors]}
 
         elif format == "DEC":
             export = {
                 "name": name,
-                "colors": [tuple([int(v*255) for v in c.rgb]) for c in colors]
+                "colors": [tuple([int(v * 255) for v in c.rgb]) for c in colors],
             }
 
         elif format == "REL":
             export = {
                 "name": name,
-                "colors": [tuple([round(v, 3) for v in c.rgb]) for c in colors]
+                "colors": [tuple([round(v, 3) for v in c.rgb]) for c in colors],
             }
 
         elif format in {"XML", "IPE"}:
-            color_values = [
-                tuple([round(v, 3) for v in c.rgb])
-                for c in colors
-            ]
+            color_values = [tuple([round(v, 3) for v in c.rgb]) for c in colors]
             color_strings = [" ".join(str(v) for v in c) for c in color_values]
             export = {
                 "name": name,
                 "colors": color_values,
                 "tags": [
-                    f"<color name=\"{name}-{i}\" value=\"{v}\" />"
+                    f'<color name="{name}-{i}" value="{v}" />'
                     for i, v in enumerate(color_strings, start=1)
-                ]
+                ],
             }
 
         return export
 
 
 if __name__ == "__main__":
-
     from pprint import pprint
 
     exported = export("Egypt", "dec")

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -1,9 +1,16 @@
 from setuptools import setup
 
+from pathlib import Path
+
+
+this_directory = Path(__file__).parent
+long_description = Path.joinpath(this_directory, "README.md").read_text(encoding="utf-8")
 
 setup(
     name="met-brewer",
-    version="1.0",
+    version="1.0.1",
     packages=["met_brewer"],
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     install_requires=["colour>=0.1.5", "matplotlib>=3.5.1"],
 )

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -5,8 +5,5 @@ setup(
     name="met-brewer",
     version="1.0",
     packages=["met_brewer"],
-    install_requires=[
-        "colour>=0.1.5",
-        "matplotlib>=3.5.1"
-    ]
+    install_requires=["colour>=0.1.5", "matplotlib>=3.5.1"],
 )

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -8,7 +8,7 @@ long_description = Path.joinpath(this_directory, "README.md").read_text(encoding
 
 setup(
     name="met-brewer",
-    version="1.0.1",
+    version="1.0.2",
     packages=["met_brewer"],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
 # MetBrewer <img align="right" src="https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Hex/MetBrewerHex.jpg" width=400>
-Palettes inspired by works at the Metropolitan Museum of Art in New York. Pieces selected come from various time periods, regions, and mediums. 
+Palettes inspired by works at the Metropolitan Museum of Art in New York. Pieces selected come from various time periods, regions, and mediums.
 
 ![CRAN Version](https://www.r-pkg.org/badges/version/MetBrewer)
 ![CRAN Downloads](https://cranlogs.r-pkg.org/badges/MetBrewer)
 
 Structure of the package was based on coding from the [`PNWColors`](https://github.com/jakelawlor/PNWColors) and [`wesanderson`](https://github.com/karthik/wesanderson) packages. Inspired by the package [`RColorBrewer`](https://cran.r-project.org/web/packages/RColorBrewer/RColorBrewer.pdf) from the work of [Cynthia Brewer](http://colorbrewer2.org).
 
-For requests, questions, comments, concerns, or any thing else, feel free to reach out to me:<br />
+For requests, questions, comments, concerns, or anything else, feel free to reach out to me:<br />
 My Website: [here](https://www.blakerobertmills.com)<br /> Twitter: [here](https://twitter.com/BlakeRobMills)<br /> LinkedIn: [here](https://www.linkedin.com/in/blake-m-79a74513a/) <br />Email: brm2143@columbia.edu
 
-# Content
-[Installation](#install-package)
-
-[Palettes](#palettes)
-
-[Functions](#functions)
-
-[Colorblind Checking](#colorblind-friendly-checking)
+# Table of Contents
+- [MetBrewer ](#metbrewer-)
+  - [Install Package](#install-package)
+    - [R](#r)
+    - [Python](#python)
+  - [Palettes](#palettes)
+  - [Functions](#functions)
+    - [ggplot2 Examples](#ggplot2-examples)
+  - [Colorblind Friendly Checking](#colorblind-friendly-checking)
 
 ## Install Package
 ### R
@@ -30,15 +31,23 @@ devtools::install_github("BlakeRMills/MetBrewer")
 ```
 
 ### Python
-Install the package under the `Python/` directory directly:
+Install via PyPA:
 ```
-python setup.py install
+pip install met-brewer
 ```
-or via pip:
+or via pip directly from GitHub:
 ```
-pip install .
+pip install -e git+https://github.com/BlakeRMills/MetBrewer#subdirectory=Python
 ```
-or place the file into your source directory.
+
+For development, install the package under the `Python/` directory:
+```
+python setup.py develop
+```
+or via pip locally:
+```
+pip install -e .
+```
 
 Use it in your code:
 ```python
@@ -51,7 +60,7 @@ colors = met_brew(name="VanGogh1", n=123, brew_type="continuous")
 ### All Palettes
 ![AllPals](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Examples/AllPalettes.png)
 
-### Archambault 
+### Archambault
 ![Archambault](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Archambault.png)
 - Woman’s Dress and Accessories, 2005, Jodi Archambault, Hunkpapa Lakota (Teton Sioux), [Link](https://www.metmuseum.org/art/collection/search/644324)
 -  Colorblind-Friendly
@@ -75,7 +84,7 @@ colors = met_brew(name="VanGogh1", n=123, brew_type="continuous")
 
 ### Cassatt2
 ![Cassatt2](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Cassatt2.png)
-- Lilacs in a Window (Vase de Lilas a la Fenetre), 1880–83, Mary Cassatt, American, [Link](https://www.metmuseum.org/art/collection/search/13758)
+- Lilacs in a Window (Vase de Lilas à la Fenetre), 1880–83, Mary Cassatt, American, [Link](https://www.metmuseum.org/art/collection/search/13758)
 - Colorblind-Friendly
 ***
 
@@ -204,7 +213,7 @@ Kleine Welten IV (Small Worlds IV), 1922, Vasily Kandinsky, French, born Russia,
 
 ### Manet
 ![Manet](https://github.com/BlakeRMills/MetBrewer/blob/main/PaletteImages/Manet.png)
-- Boating, 1874, Edouard Manet, French, [Link](https://www.metmuseum.org/art/collection/search/436947?searchField=All&amp;sortBy=Relevance&amp;ft=manet&amp;offset=0&amp;rpp=20&amp;pos=8)
+- Boating, 1874, Édouard Manet, French, [Link](https://www.metmuseum.org/art/collection/search/436947?searchField=All&amp;sortBy=Relevance&amp;ft=manet&amp;offset=0&amp;rpp=20&amp;pos=8)
 ***
 
 ### Monet
@@ -452,19 +461,19 @@ You can list out the colorblind-friendly palettes with the following code
 Python
 for palette_name, palette_dict in COLORBLIND_PALETTES.items():
     print(palette_name)
-    
+
 [1] Cassatt1, Cassatt2, Derain, Egypt, Greek, Hiroshige, Hokusai2, Hokusai3, Ingres
 [2] Isfahan1, Isfahan2, Morgenstern, OKeeffe1, OKeeffe2, Pillement, Troy, VanGogh3, Veronese
 
 R
 MetBrewer::colorblind_palettes
 
- [1] "Archambault" "Cassatt1"    "Cassatt2"    "Demuth"      "Derain"      "Egypt"       "Greek"       "Hiroshige"  
- [9] "Hokusai2"    "Hokusai3"    "Ingres"      "Isfahan1"    "Isfahan2"    "Java"        "Johnson"     "Kandinsky"  
-[17] "Morgenstern" "OKeeffe1"    "OKeeffe2"    "Pillement"   "Tam"         "Troy"        "VanGogh3"    "Veronese"   
+ [1] "Archambault" "Cassatt1"    "Cassatt2"    "Demuth"      "Derain"      "Egypt"       "Greek"       "Hiroshige"
+ [9] "Hokusai2"    "Hokusai3"    "Ingres"      "Isfahan1"    "Isfahan2"    "Java"        "Johnson"     "Kandinsky"
+[17] "Morgenstern" "OKeeffe1"    "OKeeffe2"    "Pillement"   "Tam"         "Troy"        "VanGogh3"    "Veronese"
 ```
 
-You can also test is a palettes is colorblind friendly using the function provided
+You can also test if a palette is colorblind friendly using the function provided
 
 ```r
 Python


### PR DESCRIPTION
This package is uploaded to PyPA as `met-brewer` at https://pypi.org/project/met-brewer/. If you like @BlakeRMills, I transfer ownership.

By this, MetBrewer can be installed much easier:
```bash
pip install --upgrade met-brewer
```